### PR TITLE
XAWS-9 : Setting principal key administrator the root ARN 

### DIFF
--- a/templates/xwiki.template.json
+++ b/templates/xwiki.template.json
@@ -1,1465 +1,1517 @@
 {
-    "Parameters": {
-      "xwikiversion": {
-        "Type": "String",
-        "Description": "user chosen xwiki-mysql-tomcat version name from docker hub"
+  "Parameters": {
+    "xwikiversion": {
+      "Type": "String",
+      "Description": "xwiki:stable-mysql-tomcat for stable version xwiki:lts-mysql-tomcat"
+    }
+  },
+  "Resources": {
+    "xwikivpc080875A1": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.42.42.0/24",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/Resource"
       }
     },
-    "Resources": {
-      "xwikivpc080875A1": {
-        "Type": "AWS::EC2::VPC",
-        "Properties": {
-          "CidrBlock": "10.42.42.0/24",
-          "EnableDnsHostnames": true,
-          "EnableDnsSupport": true,
-          "InstanceTenancy": "default",
-          "Tags": [
+    "xwikivpcpublicSubnet1Subnet1899EB44": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.42.42.0/27",
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
             {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc"
+              "Fn::GetAZs": ""
             }
           ]
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/Resource"
-        }
-      },
-      "xwikivpcpublicSubnet1Subnet1899EB44": {
-        "Type": "AWS::EC2::Subnet",
-        "Properties": {
-          "CidrBlock": "10.42.42.0/27",
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "public"
           },
-          "AvailabilityZone": {
-            "Fn::Select": [
-              0,
-              {
-                "Fn::GetAZs": ""
-              }
-            ]
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public"
           },
-          "MapPublicIpOnLaunch": true,
-          "Tags": [
-            {
-              "Key": "aws-cdk:subnet-name",
-              "Value": "public"
-            },
-            {
-              "Key": "aws-cdk:subnet-type",
-              "Value": "Public"
-            },
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/Subnet"
-        }
-      },
-      "xwikivpcpublicSubnet1RouteTable2DB01416": {
-        "Type": "AWS::EC2::RouteTable",
-        "Properties": {
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "Tags": [
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/RouteTable"
-        }
-      },
-      "xwikivpcpublicSubnet1RouteTableAssociation14FA90FD": {
-        "Type": "AWS::EC2::SubnetRouteTableAssociation",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcpublicSubnet1RouteTable2DB01416"
-          },
-          "SubnetId": {
-            "Ref": "xwikivpcpublicSubnet1Subnet1899EB44"
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
           }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/RouteTableAssociation"
-        }
+        ]
       },
-      "xwikivpcpublicSubnet1DefaultRoute2AB0E6C0": {
-        "Type": "AWS::EC2::Route",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcpublicSubnet1RouteTable2DB01416"
-          },
-          "DestinationCidrBlock": "0.0.0.0/0",
-          "GatewayId": {
-            "Ref": "xwikivpcIGWA9C581FA"
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/Subnet"
+      }
+    },
+    "xwikivpcpublicSubnet1RouteTable2DB01416": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
           }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/RouteTable"
+      }
+    },
+    "xwikivpcpublicSubnet1RouteTableAssociation14FA90FD": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcpublicSubnet1RouteTable2DB01416"
         },
-        "DependsOn": [
-          "xwikivpcVPCGWBC5D025F"
-        ],
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/DefaultRoute"
+        "SubnetId": {
+          "Ref": "xwikivpcpublicSubnet1Subnet1899EB44"
         }
       },
-      "xwikivpcpublicSubnet1EIP93FC5139": {
-        "Type": "AWS::EC2::EIP",
-        "Properties": {
-          "Domain": "vpc",
-          "Tags": [
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
-            }
-          ]
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/RouteTableAssociation"
+      }
+    },
+    "xwikivpcpublicSubnet1DefaultRoute2AB0E6C0": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcpublicSubnet1RouteTable2DB01416"
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/EIP"
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "xwikivpcIGWA9C581FA"
         }
       },
-      "xwikivpcpublicSubnet1NATGatewayD79F916E": {
-        "Type": "AWS::EC2::NatGateway",
-        "Properties": {
-          "AllocationId": {
-            "Fn::GetAtt": [
-              "xwikivpcpublicSubnet1EIP93FC5139",
-              "AllocationId"
-            ]
-          },
-          "SubnetId": {
-            "Ref": "xwikivpcpublicSubnet1Subnet1899EB44"
-          },
-          "Tags": [
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/NATGateway"
-        }
-      },
-      "xwikivpcpublicSubnet2Subnet629C294A": {
-        "Type": "AWS::EC2::Subnet",
-        "Properties": {
-          "CidrBlock": "10.42.42.32/27",
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "AvailabilityZone": {
-            "Fn::Select": [
-              1,
-              {
-                "Fn::GetAZs": ""
-              }
-            ]
-          },
-          "MapPublicIpOnLaunch": true,
-          "Tags": [
-            {
-              "Key": "aws-cdk:subnet-name",
-              "Value": "public"
-            },
-            {
-              "Key": "aws-cdk:subnet-type",
-              "Value": "Public"
-            },
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet2"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/Subnet"
-        }
-      },
-      "xwikivpcpublicSubnet2RouteTable0B3A590B": {
-        "Type": "AWS::EC2::RouteTable",
-        "Properties": {
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "Tags": [
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet2"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/RouteTable"
-        }
-      },
-      "xwikivpcpublicSubnet2RouteTableAssociation4982878F": {
-        "Type": "AWS::EC2::SubnetRouteTableAssociation",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcpublicSubnet2RouteTable0B3A590B"
-          },
-          "SubnetId": {
-            "Ref": "xwikivpcpublicSubnet2Subnet629C294A"
+      "DependsOn": [
+        "xwikivpcVPCGWBC5D025F"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/DefaultRoute"
+      }
+    },
+    "xwikivpcpublicSubnet1EIP93FC5139": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
           }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/RouteTableAssociation"
-        }
+        ]
       },
-      "xwikivpcpublicSubnet2DefaultRouteE5411E62": {
-        "Type": "AWS::EC2::Route",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcpublicSubnet2RouteTable0B3A590B"
-          },
-          "DestinationCidrBlock": "0.0.0.0/0",
-          "GatewayId": {
-            "Ref": "xwikivpcIGWA9C581FA"
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/EIP"
+      }
+    },
+    "xwikivpcpublicSubnet1NATGatewayD79F916E": {
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "xwikivpcpublicSubnet1EIP93FC5139",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "xwikivpcpublicSubnet1Subnet1899EB44"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet1"
           }
-        },
-        "DependsOn": [
-          "xwikivpcVPCGWBC5D025F"
-        ],
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/DefaultRoute"
-        }
+        ]
       },
-      "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8": {
-        "Type": "AWS::EC2::Subnet",
-        "Properties": {
-          "CidrBlock": "10.42.42.64/26",
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "AvailabilityZone": {
-            "Fn::Select": [
-              0,
-              {
-                "Fn::GetAZs": ""
-              }
-            ]
-          },
-          "MapPublicIpOnLaunch": false,
-          "Tags": [
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet1/NATGateway"
+      }
+    },
+    "xwikivpcpublicSubnet2Subnet629C294A": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.42.42.32/27",
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            1,
             {
-              "Key": "aws-cdk:subnet-name",
-              "Value": "private-database"
-            },
-            {
-              "Key": "aws-cdk:subnet-type",
-              "Value": "Private"
-            },
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1"
+              "Fn::GetAZs": ""
             }
           ]
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/Subnet"
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "public"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public"
+          },
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet2"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/Subnet"
+      }
+    },
+    "xwikivpcpublicSubnet2RouteTable0B3A590B": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/publicSubnet2"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/RouteTable"
+      }
+    },
+    "xwikivpcpublicSubnet2RouteTableAssociation4982878F": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcpublicSubnet2RouteTable0B3A590B"
+        },
+        "SubnetId": {
+          "Ref": "xwikivpcpublicSubnet2Subnet629C294A"
         }
       },
-      "xwikivpcprivatedatabaseSubnet1RouteTable60FFDC6D": {
-        "Type": "AWS::EC2::RouteTable",
-        "Properties": {
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "Tags": [
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/RouteTableAssociation"
+      }
+    },
+    "xwikivpcpublicSubnet2DefaultRouteE5411E62": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcpublicSubnet2RouteTable0B3A590B"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "xwikivpcIGWA9C581FA"
+        }
+      },
+      "DependsOn": [
+        "xwikivpcVPCGWBC5D025F"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/publicSubnet2/DefaultRoute"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.42.42.64/26",
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
             {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1"
+              "Fn::GetAZs": ""
             }
           ]
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/RouteTable"
-        }
-      },
-      "xwikivpcprivatedatabaseSubnet1RouteTableAssociationBCFE2614": {
-        "Type": "AWS::EC2::SubnetRouteTableAssociation",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet1RouteTable60FFDC6D"
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "private-database"
           },
-          "SubnetId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private"
+          },
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1"
           }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/RouteTableAssociation"
-        }
+        ]
       },
-      "xwikivpcprivatedatabaseSubnet1DefaultRoute92941DF7": {
-        "Type": "AWS::EC2::Route",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet1RouteTable60FFDC6D"
-          },
-          "DestinationCidrBlock": "0.0.0.0/0",
-          "NatGatewayId": {
-            "Ref": "xwikivpcpublicSubnet1NATGatewayD79F916E"
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/Subnet"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet1RouteTable60FFDC6D": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1"
           }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/RouteTable"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet1RouteTableAssociationBCFE2614": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet1RouteTable60FFDC6D"
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/DefaultRoute"
+        "SubnetId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
         }
       },
-      "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE": {
-        "Type": "AWS::EC2::Subnet",
-        "Properties": {
-          "CidrBlock": "10.42.42.128/26",
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "AvailabilityZone": {
-            "Fn::Select": [
-              1,
-              {
-                "Fn::GetAZs": ""
-              }
-            ]
-          },
-          "MapPublicIpOnLaunch": false,
-          "Tags": [
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/RouteTableAssociation"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet1DefaultRoute92941DF7": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet1RouteTable60FFDC6D"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "xwikivpcpublicSubnet1NATGatewayD79F916E"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet1/DefaultRoute"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.42.42.128/26",
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            1,
             {
-              "Key": "aws-cdk:subnet-name",
-              "Value": "private-database"
-            },
-            {
-              "Key": "aws-cdk:subnet-type",
-              "Value": "Private"
-            },
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2"
+              "Fn::GetAZs": ""
             }
           ]
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/Subnet"
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "private-database"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private"
+          },
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/Subnet"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet2RouteTable736FE060": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/RouteTable"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet2RouteTableAssociationD5027524": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet2RouteTable736FE060"
+        },
+        "SubnetId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
         }
       },
-      "xwikivpcprivatedatabaseSubnet2RouteTable736FE060": {
-        "Type": "AWS::EC2::RouteTable",
-        "Properties": {
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "Tags": [
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/RouteTableAssociation"
+      }
+    },
+    "xwikivpcprivatedatabaseSubnet2DefaultRoute0AA842AF": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet2RouteTable736FE060"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "xwikivpcpublicSubnet1NATGatewayD79F916E"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/DefaultRoute"
+      }
+    },
+    "xwikivpcIGWA9C581FA": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/xwiki-vpc"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/IGW"
+      }
+    },
+    "xwikivpcVPCGWBC5D025F": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        },
+        "InternetGatewayId": {
+          "Ref": "xwikivpcIGWA9C581FA"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/VPCGW"
+      }
+    },
+    "XWikiEncryptionKeyA3C197FE": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
             {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/RouteTable"
-        }
-      },
-      "xwikivpcprivatedatabaseSubnet2RouteTableAssociationD5027524": {
-        "Type": "AWS::EC2::SubnetRouteTableAssociation",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet2RouteTable736FE060"
-          },
-          "SubnetId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/RouteTableAssociation"
-        }
-      },
-      "xwikivpcprivatedatabaseSubnet2DefaultRoute0AA842AF": {
-        "Type": "AWS::EC2::Route",
-        "Properties": {
-          "RouteTableId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet2RouteTable736FE060"
-          },
-          "DestinationCidrBlock": "0.0.0.0/0",
-          "NatGatewayId": {
-            "Ref": "xwikivpcpublicSubnet1NATGatewayD79F916E"
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/private-databaseSubnet2/DefaultRoute"
-        }
-      },
-      "xwikivpcIGWA9C581FA": {
-        "Type": "AWS::EC2::InternetGateway",
-        "Properties": {
-          "Tags": [
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/xwiki-vpc"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/IGW"
-        }
-      },
-      "xwikivpcVPCGWBC5D025F": {
-        "Type": "AWS::EC2::VPCGatewayAttachment",
-        "Properties": {
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          },
-          "InternetGatewayId": {
-            "Ref": "xwikivpcIGWA9C581FA"
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/xwiki-vpc/VPCGW"
-        }
-      },
-      "XWikiEncryptionKeyA3C197FE": {
-        "Type": "AWS::KMS::Key",
-        "Properties": {
-          "KeyPolicy": {
-            "Statement": [
-              {
-                "Action": "kms:*",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": [
-                      "*"
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
                     ]
-                  },
-                "Resource": "*"
-              }
-            ],
-            "Version": "2012-10-17"
-          },
-          "Description": "Encryption Key for XWiki Storage Resources",
-          "Enabled": true,
-          "EnableKeyRotation": true
-        },
-        "UpdateReplacePolicy": "Retain",
-        "DeletionPolicy": "Retain",
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiEncryptionKey/Resource"
-        }
-      },
-      "XWikiEncryptionKeyAlias4CB31AE2": {
-        "Type": "AWS::KMS::Alias",
-        "Properties": {
-          "AliasName": "alias/xwiki",
-          "TargetKeyId": {
-            "Fn::GetAtt": [
-              "XWikiEncryptionKeyA3C197FE",
-              "Arn"
-            ]
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiEncryptionKey/Alias/Resource"
-        }
-      },
-      "XWikiSecretEncryptionKeyAD9C5921": {
-        "Type": "AWS::KMS::Key",
-        "Properties": {
-          "KeyPolicy": {
-            "Statement": [
-              {
-                "Action": "kms:*",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": [
-                      "*"
-                    ]
-                  },
-                "Resource": "*"
-              },
-              {
-                "Action": [
-                  "kms:Decrypt",
-                  "kms:Encrypt",
-                  "kms:ReEncrypt*",
-                  "kms:GenerateDataKey*"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "kms:ViaService": {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "secretsmanager.",
-                          {
-                            "Ref": "AWS::Region"
-                          },
-                          ".amazonaws.com"
-                        ]
-                      ]
-                    }
-                  }
-                },
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": [
-                      "*"
-                    ]
-                  },
-                "Resource": "*"
-              },
-              {
-                "Action": [
-                  "kms:CreateGrant",
-                  "kms:DescribeKey"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "kms:ViaService": {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "secretsmanager.",
-                          {
-                            "Ref": "AWS::Region"
-                          },
-                          ".amazonaws.com"
-                        ]
-                      ]
-                    }
-                  }
-                },
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": [
-                      "*"
-                    ]
-                  },
-                "Resource": "*"
-              },
-              {
-                "Action": "kms:Decrypt",
-                "Condition": {
-                  "StringEquals": {
-                    "kms:ViaService": {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "secretsmanager.",
-                          {
-                            "Ref": "AWS::Region"
-                          },
-                          ".amazonaws.com"
-                        ]
-                      ]
-                    }
-                  }
-                },
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": {
-                    "Fn::GetAtt": [
-                      "XwikiTaskRole96308875",
-                      "Arn"
-                    ]
-                  }
-                },
-                "Resource": "*"
-              }
-            ],
-            "Version": "2012-10-17"
-          },
-          "Description": "Encryption Key for XWiki Secrets",
-          "Enabled": true,
-          "EnableKeyRotation": true
-        },
-        "UpdateReplacePolicy": "Retain",
-        "DeletionPolicy": "Retain",
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiSecretEncryptionKey/Resource"
-        }
-      },
-      "XWikiSecretEncryptionKeyAlias3218F30D": {
-        "Type": "AWS::KMS::Alias",
-        "Properties": {
-          "AliasName": "alias/xwiki-secret",
-          "TargetKeyId": {
-            "Fn::GetAtt": [
-              "XWikiSecretEncryptionKeyAD9C5921",
-              "Arn"
-            ]
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiSecretEncryptionKey/Alias/Resource"
-        }
-      },
-      "XWikiEfsSecurityGroup6F17B7C8": {
-        "Type": "AWS::EC2::SecurityGroup",
-        "Properties": {
-          "GroupDescription": "Security Group for XWiki EFS",
-          "SecurityGroupEgress": [
-            {
-              "CidrIp": "0.0.0.0/0",
-              "Description": "Allow all outbound traffic by default",
-              "IpProtocol": "-1"
-            }
-          ],
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiEfsSecurityGroup/Resource"
-        }
-      },
-      "XWikiEfsSecurityGroupfromxwikiproductionstacksXWikiTaskSecurityGroup17064AAE20490C640D00": {
-        "Type": "AWS::EC2::SecurityGroupIngress",
-        "Properties": {
-          "IpProtocol": "tcp",
-          "Description": "Allow NFS Connection for XWiki Service",
-          "FromPort": 2049,
-          "GroupId": {
-            "Fn::GetAtt": [
-              "XWikiEfsSecurityGroup6F17B7C8",
-              "GroupId"
-            ]
-          },
-          "SourceSecurityGroupId": {
-            "Fn::GetAtt": [
-              "XWikiTaskSecurityGroupA510E380",
-              "GroupId"
-            ]
-          },
-          "ToPort": 2049
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiEfsSecurityGroup/from xwikiproductionstacksXWikiTaskSecurityGroup17064AAE:2049"
-        }
-      },
-      "XWikiFileSystem3F0B6908": {
-        "Type": "AWS::EFS::FileSystem",
-        "Properties": {
-          "BackupPolicy": {
-            "Status": "ENABLED"
-          },
-          "Encrypted": true,
-          "FileSystemTags": [
-            {
-              "Key": "Name",
-              "Value": "xwiki-production-stacks/XWikiFileSystem"
-            }
-          ],
-          "KmsKeyId": {
-            "Fn::GetAtt": [
-              "XWikiEncryptionKeyA3C197FE",
-              "Arn"
-            ]
-          },
-          "PerformanceMode": "generalPurpose"
-        },
-        "UpdateReplacePolicy": "Retain",
-        "DeletionPolicy": "Retain",
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiFileSystem/Resource"
-        }
-      },
-      "XWikiFileSystemEfsMountTarget1D86D8A8F": {
-        "Type": "AWS::EFS::MountTarget",
-        "Properties": {
-          "FileSystemId": {
-            "Ref": "XWikiFileSystem3F0B6908"
-          },
-          "SecurityGroups": [
-            {
-              "Fn::GetAtt": [
-                "XWikiEfsSecurityGroup6F17B7C8",
-                "GroupId"
-              ]
-            }
-          ],
-          "SubnetId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiFileSystem/EfsMountTarget1"
-        }
-      },
-      "XWikiFileSystemEfsMountTarget2E8029D4C": {
-        "Type": "AWS::EFS::MountTarget",
-        "Properties": {
-          "FileSystemId": {
-            "Ref": "XWikiFileSystem3F0B6908"
-          },
-          "SecurityGroups": [
-            {
-              "Fn::GetAtt": [
-                "XWikiEfsSecurityGroup6F17B7C8",
-                "GroupId"
-              ]
-            }
-          ],
-          "SubnetId": {
-            "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiFileSystem/EfsMountTarget2"
-        }
-      },
-      "XWikiRdsSecurityGroup1C2538B9": {
-        "Type": "AWS::EC2::SecurityGroup",
-        "Properties": {
-          "GroupDescription": "Security Group for XWiki RDS",
-          "SecurityGroupEgress": [
-            {
-              "CidrIp": "0.0.0.0/0",
-              "Description": "Allow all outbound traffic by default",
-              "IpProtocol": "-1"
-            }
-          ],
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiRdsSecurityGroup/Resource"
-        }
-      },
-      "XWikiRdsSecurityGroupfromxwikiproductionstacksXWikiTaskSecurityGroup17064AAEIndirectPort1BC2C4F8": {
-        "Type": "AWS::EC2::SecurityGroupIngress",
-        "Properties": {
-          "IpProtocol": "tcp",
-          "Description": "Allow DB Connection for XWiki Service",
-          "FromPort": {
-            "Fn::GetAtt": [
-              "XWikiDbCluster54525188",
-              "Endpoint.Port"
-            ]
-          },
-          "GroupId": {
-            "Fn::GetAtt": [
-              "XWikiRdsSecurityGroup1C2538B9",
-              "GroupId"
-            ]
-          },
-          "SourceSecurityGroupId": {
-            "Fn::GetAtt": [
-              "XWikiTaskSecurityGroupA510E380",
-              "GroupId"
-            ]
-          },
-          "ToPort": {
-            "Fn::GetAtt": [
-              "XWikiDbCluster54525188",
-              "Endpoint.Port"
-            ]
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiRdsSecurityGroup/from xwikiproductionstacksXWikiTaskSecurityGroup17064AAE:{IndirectPort}"
-        }
-      },
-      "XWikiDbSubnetGroup": {
-        "Type": "AWS::RDS::DBSubnetGroup",
-        "Properties": {
-          "DBSubnetGroupDescription": "DB SubnetGroup for XWiki RDS",
-          "SubnetIds": [
-            {
-              "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
-            },
-            {
-              "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiDbSubnetGroup/Default"
-        }
-      },
-      "XWikiEcsUserPassword39EA7E1F": {
-        "Type": "AWS::SecretsManager::Secret",
-        "Properties": {
-          "Description": "RDS UserSecret for XWiki RDS",
-          "GenerateSecretString": {
-            "ExcludePunctuation": true,
-            "PasswordLength": 16
-          },
-          "KmsKeyId": {
-            "Fn::GetAtt": [
-              "XWikiSecretEncryptionKeyAD9C5921",
-              "Arn"
-            ]
-          }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiEcsUserPassword/Resource"
-        }
-      },
-      "XWikiDbCluster54525188": {
-        "Type": "AWS::RDS::DBCluster",
-        "Properties": {
-          "Engine": "aurora-mysql",
-          "BackupRetentionPeriod": 7,
-          "DatabaseName": "xwiki",
-          "DBClusterParameterGroupName": "default.aurora-mysql5.7",
-          "DBSubnetGroupName": {
-            "Ref": "XWikiDbSubnetGroup"
-          },
-          "EngineMode": "serverless",
-          "EngineVersion": "5.7.mysql_aurora.2.07.1",
-          "KmsKeyId": {
-            "Fn::GetAtt": [
-              "XWikiEncryptionKeyA3C197FE",
-              "Arn"
-            ]
-          },
-          "MasterUsername": "xwikimysql",
-          "MasterUserPassword": {
-            "Fn::Join": [
-              "",
-              [
-                "{{resolve:secretsmanager:",
-                {
-                  "Ref": "XWikiEcsUserPassword39EA7E1F"
-                },
-                ":SecretString:::}}"
-              ]
-            ]
-          },
-          "ScalingConfiguration": {
-            "AutoPause": false,
-            "MaxCapacity": 8,
-            "MinCapacity": 1
-          },
-          "StorageEncrypted": true,
-          "VpcSecurityGroupIds": [
-            {
-              "Fn::GetAtt": [
-                "XWikiRdsSecurityGroup1C2538B9",
-                "GroupId"
-              ]
-            }
-          ]
-        },
-        "UpdateReplacePolicy": "Snapshot",
-        "DeletionPolicy": "Snapshot",
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiDbCluster/Resource"
-        }
-      },
-      "XWikiClusterF2F3955C": {
-        "Type": "AWS::ECS::Cluster",
-        "Properties": {
-          "ClusterSettings": [
-            {
-              "Name": "containerInsights",
-              "Value": "enabled"
-            }
-          ]
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiCluster/Resource"
-        }
-      },
-      "XwikiTaskRole96308875": {
-        "Type": "AWS::IAM::Role",
-        "Properties": {
-          "AssumeRolePolicyDocument": {
-            "Statement": [
-              {
-                "Action": "sts:AssumeRole",
-                "Effect": "Allow",
-                "Principal": {
-                  "Service": "ecs-tasks.amazonaws.com"
+                  ]
                 }
-              }
-            ],
-            "Version": "2012-10-17"
-          },
-          "Description": "IAM Task Role for XWiki ECS Fargate"
+              },
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XwikiTaskRole/Resource"
+        "Description": "Encryption Key for XWiki Storage Resources",
+        "Enabled": true,
+        "EnableKeyRotation": true
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiEncryptionKey/Resource"
+      }
+    },
+    "XWikiEncryptionKeyAlias4CB31AE2": {
+      "Type": "AWS::KMS::Alias",
+      "Properties": {
+        "AliasName": "alias/xwiki",
+        "TargetKeyId": {
+          "Fn::GetAtt": [
+            "XWikiEncryptionKeyA3C197FE",
+            "Arn"
+          ]
         }
       },
-      "XwikiTaskRoleDefaultPolicy03A798A3": {
-        "Type": "AWS::IAM::Policy",
-        "Properties": {
-          "PolicyDocument": {
-            "Statement": [
-              {
-                "Action": [
-                  "logs:CreateLogStream",
-                  "logs:PutLogEvents"
-                ],
-                "Effect": "Allow",
-                "Resource": {
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiEncryptionKey/Alias/Resource"
+      }
+    },
+    "XWikiSecretEncryptionKeyAD9C5921": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "secretsmanager.",
+                        {
+                          "Ref": "AWS::Region"
+                        },
+                        ".amazonaws.com"
+                      ]
+                    ]
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "kms:CreateGrant",
+                "kms:DescribeKey"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "secretsmanager.",
+                        {
+                          "Ref": "AWS::Region"
+                        },
+                        ".amazonaws.com"
+                      ]
+                    ]
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              },
+              "Resource": "*"
+            },
+            {
+              "Action": "kms:Decrypt",
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "secretsmanager.",
+                        {
+                          "Ref": "AWS::Region"
+                        },
+                        ".amazonaws.com"
+                      ]
+                    ]
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
                   "Fn::GetAtt": [
-                    "XWikiLogGroup9C7714A4",
+                    "XwikiTaskRole96308875",
                     "Arn"
                   ]
                 }
               },
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Description": "Encryption Key for XWiki Secrets",
+        "Enabled": true,
+        "EnableKeyRotation": true
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiSecretEncryptionKey/Resource"
+      }
+    },
+    "XWikiSecretEncryptionKeyAlias3218F30D": {
+      "Type": "AWS::KMS::Alias",
+      "Properties": {
+        "AliasName": "alias/xwiki-secret",
+        "TargetKeyId": {
+          "Fn::GetAtt": [
+            "XWikiSecretEncryptionKeyAD9C5921",
+            "Arn"
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiSecretEncryptionKey/Alias/Resource"
+      }
+    },
+    "XWikiEfsSecurityGroup6F17B7C8": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Security Group for XWiki EFS",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1"
+          }
+        ],
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiEfsSecurityGroup/Resource"
+      }
+    },
+    "XWikiEfsSecurityGroupfromxwikiproductionstacksXWikiTaskSecurityGroup17064AAE20490C640D00": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "Description": "Allow NFS Connection for XWiki Service",
+        "FromPort": 2049,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "XWikiEfsSecurityGroup6F17B7C8",
+            "GroupId"
+          ]
+        },
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "XWikiTaskSecurityGroupA510E380",
+            "GroupId"
+          ]
+        },
+        "ToPort": 2049
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiEfsSecurityGroup/from xwikiproductionstacksXWikiTaskSecurityGroup17064AAE:2049"
+      }
+    },
+    "XWikiFileSystem3F0B6908": {
+      "Type": "AWS::EFS::FileSystem",
+      "Properties": {
+        "BackupPolicy": {
+          "Status": "ENABLED"
+        },
+        "Encrypted": true,
+        "FileSystemTags": [
+          {
+            "Key": "Name",
+            "Value": "xwiki-production-stacks/XWikiFileSystem"
+          }
+        ],
+        "KmsKeyId": {
+          "Fn::GetAtt": [
+            "XWikiEncryptionKeyA3C197FE",
+            "Arn"
+          ]
+        },
+        "PerformanceMode": "generalPurpose"
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiFileSystem/Resource"
+      }
+    },
+    "XWikiFileSystemEfsMountTarget1D86D8A8F": {
+      "Type": "AWS::EFS::MountTarget",
+      "Properties": {
+        "FileSystemId": {
+          "Ref": "XWikiFileSystem3F0B6908"
+        },
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "XWikiEfsSecurityGroup6F17B7C8",
+              "GroupId"
+            ]
+          }
+        ],
+        "SubnetId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiFileSystem/EfsMountTarget1"
+      }
+    },
+    "XWikiFileSystemEfsMountTarget2E8029D4C": {
+      "Type": "AWS::EFS::MountTarget",
+      "Properties": {
+        "FileSystemId": {
+          "Ref": "XWikiFileSystem3F0B6908"
+        },
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "XWikiEfsSecurityGroup6F17B7C8",
+              "GroupId"
+            ]
+          }
+        ],
+        "SubnetId": {
+          "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiFileSystem/EfsMountTarget2"
+      }
+    },
+    "XWikiRdsSecurityGroup1C2538B9": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Security Group for XWiki RDS",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1"
+          }
+        ],
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiRdsSecurityGroup/Resource"
+      }
+    },
+    "XWikiRdsSecurityGroupfromxwikiproductionstacksXWikiTaskSecurityGroup17064AAEIndirectPort1BC2C4F8": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "Description": "Allow DB Connection for XWiki Service",
+        "FromPort": {
+          "Fn::GetAtt": [
+            "XWikiDbCluster54525188",
+            "Endpoint.Port"
+          ]
+        },
+        "GroupId": {
+          "Fn::GetAtt": [
+            "XWikiRdsSecurityGroup1C2538B9",
+            "GroupId"
+          ]
+        },
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "XWikiTaskSecurityGroupA510E380",
+            "GroupId"
+          ]
+        },
+        "ToPort": {
+          "Fn::GetAtt": [
+            "XWikiDbCluster54525188",
+            "Endpoint.Port"
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiRdsSecurityGroup/from xwikiproductionstacksXWikiTaskSecurityGroup17064AAE:{IndirectPort}"
+      }
+    },
+    "XWikiDbSubnetGroup": {
+      "Type": "AWS::RDS::DBSubnetGroup",
+      "Properties": {
+        "DBSubnetGroupDescription": "DB SubnetGroup for XWiki RDS",
+        "SubnetIds": [
+          {
+            "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
+          },
+          {
+            "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiDbSubnetGroup/Default"
+      }
+    },
+    "XWikiEcsUserPassword39EA7E1F": {
+      "Type": "AWS::SecretsManager::Secret",
+      "Properties": {
+        "Description": "RDS UserSecret for XWiki RDS",
+        "GenerateSecretString": {
+          "ExcludePunctuation": true,
+          "PasswordLength": 16
+        },
+        "KmsKeyId": {
+          "Fn::GetAtt": [
+            "XWikiSecretEncryptionKeyAD9C5921",
+            "Arn"
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiEcsUserPassword/Resource"
+      }
+    },
+    "XWikiDbCluster54525188": {
+      "Type": "AWS::RDS::DBCluster",
+      "Properties": {
+        "Engine": "aurora-mysql",
+        "BackupRetentionPeriod": 7,
+        "DatabaseName": "xwiki",
+        "DBClusterParameterGroupName": "default.aurora-mysql5.7",
+        "DBSubnetGroupName": {
+          "Ref": "XWikiDbSubnetGroup"
+        },
+        "EngineMode": "serverless",
+        "EngineVersion": "5.7.mysql_aurora.2.07.1",
+        "KmsKeyId": {
+          "Fn::GetAtt": [
+            "XWikiEncryptionKeyA3C197FE",
+            "Arn"
+          ]
+        },
+        "MasterUsername": "xwikimysql",
+        "MasterUserPassword": {
+          "Fn::Join": [
+            "",
+            [
+              "{{resolve:secretsmanager:",
               {
-                "Action": [
-                  "secretsmanager:GetSecretValue",
-                  "secretsmanager:DescribeSecret"
-                ],
-                "Effect": "Allow",
-                "Resource": {
+                "Ref": "XWikiEcsUserPassword39EA7E1F"
+              },
+              ":SecretString:::}}"
+            ]
+          ]
+        },
+        "ScalingConfiguration": {
+          "AutoPause": false,
+          "MaxCapacity": 8,
+          "MinCapacity": 1
+        },
+        "StorageEncrypted": true,
+        "VpcSecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "XWikiRdsSecurityGroup1C2538B9",
+              "GroupId"
+            ]
+          }
+        ]
+      },
+      "UpdateReplacePolicy": "Snapshot",
+      "DeletionPolicy": "Snapshot",
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiDbCluster/Resource"
+      }
+    },
+    "XWikiClusterF2F3955C": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterSettings": [
+          {
+            "Name": "containerInsights",
+            "Value": "enabled"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiCluster/Resource"
+      }
+    },
+    "XwikiTaskRole96308875": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Description": "IAM Task Role for XWiki ECS Fargate"
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XwikiTaskRole/Resource"
+      }
+    },
+    "XwikiTaskRoleDefaultPolicy03A798A3": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "XWikiLogGroup9C7714A4",
+                  "Arn"
+                ]
+              }
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "XWikiEcsUserPassword39EA7E1F"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "XwikiTaskRoleDefaultPolicy03A798A3",
+        "Roles": [
+          {
+            "Ref": "XwikiTaskRole96308875"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XwikiTaskRole/DefaultPolicy/Resource"
+      }
+    },
+    "XWikiTaskDefinition7B4CCDA9": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "XWikiDbCluster54525188",
+                    "Endpoint.Address"
+                  ]
+                }
+              },
+              {
+                "Name": "DB_DATABASE",
+                "Value": "xwiki"
+              },
+              {
+                "Name": "DB_USER",
+                "Value": "xwikimysql"
+              }
+            ],
+            "Essential": true,
+            "Image": {
+              "Ref": "xwikiversion"
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "XWikiLogGroup9C7714A4"
+                },
+                "awslogs-stream-prefix": "xwiki",
+                "awslogs-region": {
+                  "Ref": "AWS::Region"
+                }
+              }
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/usr/local/xwiki/data",
+                "ReadOnly": false,
+                "SourceVolume": "EfsPersistendVolume"
+              }
+            ],
+            "Name": "XWikiImage",
+            "PortMappings": [
+              {
+                "ContainerPort": 8080,
+                "Protocol": "tcp"
+              }
+            ],
+            "Secrets": [
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
                   "Ref": "XWikiEcsUserPassword39EA7E1F"
                 }
               }
-            ],
-            "Version": "2012-10-17"
-          },
-          "PolicyName": "XwikiTaskRoleDefaultPolicy03A798A3",
-          "Roles": [
-            {
-              "Ref": "XwikiTaskRole96308875"
-            }
+            ]
+          }
+        ],
+        "Cpu": "2048",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "XwikiTaskRole96308875",
+            "Arn"
           ]
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XwikiTaskRole/DefaultPolicy/Resource"
-        }
-      },
-      "XWikiTaskDefinition7B4CCDA9": {
-        "Type": "AWS::ECS::TaskDefinition",
-        "Properties": {
-          "ContainerDefinitions": [
-            {
-              "Environment": [
-                {
-                  "Name": "DB_HOST",
-                  "Value": {
-                    "Fn::GetAtt": [
-                      "XWikiDbCluster54525188",
-                      "Endpoint.Address"
-                    ]
-                  }
-                },
-                {
-                  "Name": "DB_DATABASE",
-                  "Value": "xwiki"
-                },
-                {
-                  "Name": "DB_USER",
-                  "Value": "xwikimysql"
-                }
-              ],
-              "Essential": true,
-              "Image": {
-                "Ref": "xwikiversion"
-              },
-              "LogConfiguration": {
-                "LogDriver": "awslogs",
-                "Options": {
-                  "awslogs-group": {
-                    "Ref": "XWikiLogGroup9C7714A4"
-                  },
-                  "awslogs-stream-prefix": "xwiki",
-                  "awslogs-region": {
-                    "Ref": "AWS::Region"
-                  }
-                }
-              },
-              "MountPoints": [
-                {
-                  "ContainerPath": "/usr/local/xwiki/data",
-                  "ReadOnly": false,
-                  "SourceVolume": "EfsPersistendVolume"
-                }
-              ],
-              "Name": "XWikiImage",
-              "PortMappings": [
-                {
-                  "ContainerPort": 8080,
-                  "Protocol": "tcp"
-                }
-              ],
-              "Secrets": [
-                {
-                  "Name": "DB_PASSWORD",
-                  "ValueFrom": {
-                    "Ref": "XWikiEcsUserPassword39EA7E1F"
-                  }
-                }
-              ]
-            }
-          ],
-          "Cpu": "2048",
-          "ExecutionRoleArn": {
-            "Fn::GetAtt": [
-              "XwikiTaskRole96308875",
-              "Arn"
-            ]
-          },
-          "Family": "xwikiproductionstacksXWikiTaskDefinition949BE419",
-          "Memory": "4096",
-          "NetworkMode": "awsvpc",
-          "RequiresCompatibilities": [
-            "FARGATE"
-          ],
-          "TaskRoleArn": {
-            "Fn::GetAtt": [
-              "XwikiTaskRole96308875",
-              "Arn"
-            ]
-          },
-          "Volumes": [
-            {
-              "Name": "EfsPersistendVolume",
-              "EfsVolumeConfiguration": {
-                "RootDirectory": "/",
-                "TransitEncryption": "ENABLED",
-                "FileSystemId": {
-                  "Ref": "XWikiFileSystem3F0B6908"
-                }
+        "Family": "xwikiproductionstacksXWikiTaskDefinition949BE419",
+        "Memory": "4096",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "XwikiTaskRole96308875",
+            "Arn"
+          ]
+        },
+        "Volumes": [
+          {
+            "Name": "EfsPersistendVolume",
+            "EfsVolumeConfiguration": {
+              "RootDirectory": "/",
+              "TransitEncryption": "ENABLED",
+              "FileSystemId": {
+                "Ref": "XWikiFileSystem3F0B6908"
               }
             }
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiTaskDefinition/Resource"
+      }
+    },
+    "XWikiLogGroup9C7714A4": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "RetentionInDays": 30
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiLogGroup/Resource"
+      }
+    },
+    "XWikiTaskSecurityGroupA510E380": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "SecurityGroup for XWiki ECS Fargate Service",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1"
+          }
+        ],
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiTaskSecurityGroup/Resource"
+      }
+    },
+    "XWikiTaskSecurityGroupfromxwikiproductionstacksXWikiAlbSecurityGroupCFD4B08F8080D902CFD5": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "Description": "Allow HTTP Connections for XWiki ECS Application LoadBalancer",
+        "FromPort": 8080,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "XWikiTaskSecurityGroupA510E380",
+            "GroupId"
           ]
         },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiTaskDefinition/Resource"
-        }
-      },
-      "XWikiLogGroup9C7714A4": {
-        "Type": "AWS::Logs::LogGroup",
-        "Properties": {
-          "RetentionInDays": 30
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "XWikiAlbSecurityGroup36150782",
+            "GroupId"
+          ]
         },
-        "UpdateReplacePolicy": "Retain",
-        "DeletionPolicy": "Retain",
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiLogGroup/Resource"
-        }
+        "ToPort": 8080
       },
-      "XWikiTaskSecurityGroupA510E380": {
-        "Type": "AWS::EC2::SecurityGroup",
-        "Properties": {
-          "GroupDescription": "SecurityGroup for XWiki ECS Fargate Service",
-          "SecurityGroupEgress": [
-            {
-              "CidrIp": "0.0.0.0/0",
-              "Description": "Allow all outbound traffic by default",
-              "IpProtocol": "-1"
-            }
-          ],
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiTaskSecurityGroup/from xwikiproductionstacksXWikiAlbSecurityGroupCFD4B08F:8080"
+      }
+    },
+    "XWikiAlbSecurityGroup36150782": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "SecurityGroup for XWiki Application LoadBalancer",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1"
           }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiTaskSecurityGroup/Resource"
+        ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow HTTP Connections for the World to Application LoadBalancer",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80
+          }
+        ],
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
         }
       },
-      "XWikiTaskSecurityGroupfromxwikiproductionstacksXWikiAlbSecurityGroupCFD4B08F8080D902CFD5": {
-        "Type": "AWS::EC2::SecurityGroupIngress",
-        "Properties": {
-          "IpProtocol": "tcp",
-          "Description": "Allow HTTP Connections for XWiki ECS Application LoadBalancer",
-          "FromPort": 8080,
-          "GroupId": {
-            "Fn::GetAtt": [
-              "XWikiTaskSecurityGroupA510E380",
-              "GroupId"
-            ]
-          },
-          "SourceSecurityGroupId": {
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiAlbSecurityGroup/Resource"
+      }
+    },
+    "XWikiLoadBalancer122DE243": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "false"
+          }
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
             "Fn::GetAtt": [
               "XWikiAlbSecurityGroup36150782",
               "GroupId"
             ]
-          },
-          "ToPort": 8080
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiTaskSecurityGroup/from xwikiproductionstacksXWikiAlbSecurityGroupCFD4B08F:8080"
-        }
-      },
-      "XWikiAlbSecurityGroup36150782": {
-        "Type": "AWS::EC2::SecurityGroup",
-        "Properties": {
-          "GroupDescription": "SecurityGroup for XWiki Application LoadBalancer",
-          "SecurityGroupEgress": [
-            {
-              "CidrIp": "0.0.0.0/0",
-              "Description": "Allow all outbound traffic by default",
-              "IpProtocol": "-1"
-            }
-          ],
-          "SecurityGroupIngress": [
-            {
-              "CidrIp": "0.0.0.0/0",
-              "Description": "Allow HTTP Connections for the World to Application LoadBalancer",
-              "FromPort": 80,
-              "IpProtocol": "tcp",
-              "ToPort": 80
-            }
-          ],
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
           }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiAlbSecurityGroup/Resource"
-        }
+        ],
+        "Subnets": [
+          {
+            "Ref": "xwikivpcpublicSubnet1Subnet1899EB44"
+          },
+          {
+            "Ref": "xwikivpcpublicSubnet2Subnet629C294A"
+          }
+        ],
+        "Type": "application"
       },
-      "XWikiLoadBalancer122DE243": {
-        "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-        "Properties": {
-          "LoadBalancerAttributes": [
-            {
-              "Key": "deletion_protection.enabled",
-              "Value": "false"
-            }
-          ],
-          "Scheme": "internet-facing",
-          "SecurityGroups": [
-            {
-              "Fn::GetAtt": [
-                "XWikiAlbSecurityGroup36150782",
-                "GroupId"
-              ]
-            }
-          ],
-          "Subnets": [
-            {
-              "Ref": "xwikivpcpublicSubnet1Subnet1899EB44"
+      "DependsOn": [
+        "xwikivpcpublicSubnet1DefaultRoute2AB0E6C0",
+        "xwikivpcpublicSubnet2DefaultRouteE5411E62"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiLoadBalancer/Resource"
+      }
+    },
+    "XWikiLoadBalancerXWikiLoadBalancerHttpListener9D892486": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9"
             },
-            {
-              "Ref": "xwikivpcpublicSubnet2Subnet629C294A"
-            }
-          ],
-          "Type": "application"
-        },
-        "DependsOn": [
-          "xwikivpcpublicSubnet1DefaultRoute2AB0E6C0",
-          "xwikivpcpublicSubnet2DefaultRouteE5411E62"
-        ],
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiLoadBalancer/Resource"
-        }
-      },
-      "XWikiLoadBalancerXWikiLoadBalancerHttpListener9D892486": {
-        "Type": "AWS::ElasticLoadBalancingV2::Listener",
-        "Properties": {
-          "DefaultActions": [
-            {
-              "TargetGroupArn": {
-                "Ref": "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9"
-              },
-              "Type": "forward"
-            }
-          ],
-          "LoadBalancerArn": {
-            "Ref": "XWikiLoadBalancer122DE243"
-          },
-          "Port": 80,
-          "Protocol": "HTTP"
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiLoadBalancer/XWikiLoadBalancerHttpListener/Resource"
-        }
-      },
-      "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9": {
-        "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-        "Properties": {
-          "Matcher": {
-            "HttpCode": "200,301,302"
-          },
-          "Port": 80,
-          "Protocol": "HTTP",
-          "TargetGroupAttributes": [
-            {
-              "Key": "deregistration_delay.timeout_seconds",
-              "Value": "60"
-            }
-          ],
-          "TargetType": "ip",
-          "VpcId": {
-            "Ref": "xwikivpc080875A1"
+            "Type": "forward"
           }
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiLoadBalancer/XWikiLoadBalancerHttpListener/XWikiTargetsGroup/Resource"
-        }
-      },
-      "XWikiService9DBC567A": {
-        "Type": "AWS::ECS::Service",
-        "Properties": {
-          "Cluster": {
-            "Ref": "XWikiClusterF2F3955C"
-          },
-          "DeploymentConfiguration": {
-            "MaximumPercent": 200,
-            "MinimumHealthyPercent": 50
-          },
-          "DesiredCount": 1,
-          "EnableECSManagedTags": false,
-          "HealthCheckGracePeriodSeconds": 60,
-          "LaunchType": "FARGATE",
-          "LoadBalancers": [
-            {
-              "ContainerName": "XWikiImage",
-              "ContainerPort": 8080,
-              "TargetGroupArn": {
-                "Ref": "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9"
-              }
-            }
-          ],
-          "NetworkConfiguration": {
-            "AwsvpcConfiguration": {
-              "AssignPublicIp": "DISABLED",
-              "SecurityGroups": [
-                {
-                  "Fn::GetAtt": [
-                    "XWikiTaskSecurityGroupA510E380",
-                    "GroupId"
-                  ]
-                }
-              ],
-              "Subnets": [
-                {
-                  "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
-                },
-                {
-                  "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
-                }
-              ]
-            }
-          },
-          "PlatformVersion": "1.4.0",
-          "TaskDefinition": {
-            "Ref": "XWikiTaskDefinition7B4CCDA9"
-          }
-        },
-        "DependsOn": [
-          "XWikiLoadBalancerXWikiLoadBalancerHttpListener9D892486",
-          "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9"
         ],
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/XWikiService/Service"
-        }
+        "LoadBalancerArn": {
+          "Ref": "XWikiLoadBalancer122DE243"
+        },
+        "Port": 80,
+        "Protocol": "HTTP"
       },
-      "CDKMetadata": {
-        "Type": "AWS::CDK::Metadata",
-        "Properties": {
-          "Analytics": "v2:deflate64:H4sIAAAAAAAAA31TS2/bMAz+LburblNsPS9NHwjWdUZc9M7IjMtGlgw9UgSG/vso2U7cHnrix/dHkVoUi6tfxdWP3/DhLmS9v+ylsVj0lQe5F6udLsFCix6t2KAzwUpM1n/Bd8GLldHO2yB9ss397KjJk9FRpMI9yuuif+1k8r2WK1GGrSJZha3GnHtGGxM8vsBW4dl+ti2dM5IgVT4FJ3C/LpN4Bv8IHj/gKEpLB4bnwmvNQzCeAgYmo7b0PO9bi9qLCmWw5I+P1oQuc/jWsNaNReei2Leu6P9gLpzEUhG4pGQQBe7Y/0AKq6Pz2CbPZ+2vCdq/gG3QR2Frjh7In/re3c4NFdoDWsW9Vyq4tKAcMipROJQWvWtBQ4OWi2V95G9TD5TcY5Y8wQfmAOnB3f4Od6Rpeu6vFqM9kEY7s425iRwNpzDCKAjaot+YYbFZloaPID/YgKJQpmFOT6Y5DT1hpqvAeZLKQL0FBVqSbg58Vsuu4+R8E0/su82+YaJP+jyOeFA9xkx45h+2cOIwU2OMQpsai3d3eVj8LG7477w7ogvLy6MWi80g/wPXjZGEWAMAAA=="
-        },
-        "Metadata": {
-          "aws:cdk:path": "xwiki-production-stacks/CDKMetadata/Default"
-        },
-        "Condition": "CDKMetadataAvailable"
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiLoadBalancer/XWikiLoadBalancerHttpListener/Resource"
       }
     },
-    "Outputs": {
-      "XWikiLoadBalancerDns": {
-        "Description": "DNS Endpoint for connecting to the XWiki Installation",
-        "Value": {
-          "Fn::GetAtt": [
-            "XWikiLoadBalancer122DE243",
-            "DNSName"
-          ]
+    "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Matcher": {
+          "HttpCode": "200,301,302"
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "60"
+          }
+        ],
+        "TargetType": "ip",
+        "VpcId": {
+          "Ref": "xwikivpc080875A1"
         }
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiLoadBalancer/XWikiLoadBalancerHttpListener/XWikiTargetsGroup/Resource"
       }
     },
-    "Conditions": {
-      "CDKMetadataAvailable": {
-        "Fn::Or": [
+    "XWikiService9DBC567A": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "Cluster": {
+          "Ref": "XWikiClusterF2F3955C"
+        },
+        "DeploymentConfiguration": {
+          "MaximumPercent": 200,
+          "MinimumHealthyPercent": 50
+        },
+        "DesiredCount": 1,
+        "EnableECSManagedTags": false,
+        "HealthCheckGracePeriodSeconds": 60,
+        "LaunchType": "FARGATE",
+        "LoadBalancers": [
           {
-            "Fn::Or": [
+            "ContainerName": "XWikiImage",
+            "ContainerPort": 8080,
+            "TargetGroupArn": {
+              "Ref": "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9"
+            }
+          }
+        ],
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": [
               {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "af-south-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "ap-east-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "ap-northeast-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "ap-northeast-2"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "ap-south-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "ap-southeast-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "ap-southeast-2"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "ca-central-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "cn-north-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "cn-northwest-1"
+                "Fn::GetAtt": [
+                  "XWikiTaskSecurityGroupA510E380",
+                  "GroupId"
                 ]
               }
-            ]
-          },
-          {
-            "Fn::Or": [
+            ],
+            "Subnets": [
               {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "eu-central-1"
-                ]
+                "Ref": "xwikivpcprivatedatabaseSubnet1Subnet996FCDD8"
               },
               {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "eu-north-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "eu-south-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "eu-west-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "eu-west-2"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "eu-west-3"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "me-south-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "sa-east-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "us-east-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "us-east-2"
-                ]
-              }
-            ]
-          },
-          {
-            "Fn::Or": [
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "us-west-1"
-                ]
-              },
-              {
-                "Fn::Equals": [
-                  {
-                    "Ref": "AWS::Region"
-                  },
-                  "us-west-2"
-                ]
+                "Ref": "xwikivpcprivatedatabaseSubnet2SubnetA4D4B2EE"
               }
             ]
           }
+        },
+        "PlatformVersion": "1.4.0",
+        "TaskDefinition": {
+          "Ref": "XWikiTaskDefinition7B4CCDA9"
+        }
+      },
+      "DependsOn": [
+        "XWikiLoadBalancerXWikiLoadBalancerHttpListener9D892486",
+        "XWikiLoadBalancerXWikiLoadBalancerHttpListenerXWikiTargetsGroup7EF649B9"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/XWikiService/Service"
+      }
+    },
+    "CDKMetadata": {
+      "Type": "AWS::CDK::Metadata",
+      "Properties": {
+        "Analytics": "v2:deflate64:H4sIAAAAAAAAA31TS2/bMAz+LburblNsPS9NHwjWdUZc9M7IjMtGlgw9UgSG/vso2U7cHnrix/dHkVoUi6tfxdWP3/DhLmS9v+ylsVj0lQe5F6udLsFCix6t2KAzwUpM1n/Bd8GLldHO2yB9ss397KjJk9FRpMI9yuuif+1k8r2WK1GGrSJZha3GnHtGGxM8vsBW4dl+ti2dM5IgVT4FJ3C/LpN4Bv8IHj/gKEpLB4bnwmvNQzCeAgYmo7b0PO9bi9qLCmWw5I+P1oQuc/jWsNaNReei2Leu6P9gLpzEUhG4pGQQBe7Y/0AKq6Pz2CbPZ+2vCdq/gG3QR2Frjh7In/re3c4NFdoDWsW9Vyq4tKAcMipROJQWvWtBQ4OWi2V95G9TD5TcY5Y8wQfmAOnB3f4Od6Rpeu6vFqM9kEY7s425iRwNpzDCKAjaot+YYbFZloaPID/YgKJQpmFOT6Y5DT1hpqvAeZLKQL0FBVqSbg58Vsuu4+R8E0/su82+YaJP+jyOeFA9xkx45h+2cOIwU2OMQpsai3d3eVj8LG7477w7ogvLy6MWi80g/wPXjZGEWAMAAA=="
+      },
+      "Metadata": {
+        "aws:cdk:path": "xwiki-production-stacks/CDKMetadata/Default"
+      },
+      "Condition": "CDKMetadataAvailable"
+    }
+  },
+  "Outputs": {
+    "XWikiLoadBalancerDns": {
+      "Description": "DNS Endpoint for connecting to the XWiki Installation",
+      "Value": {
+        "Fn::GetAtt": [
+          "XWikiLoadBalancer122DE243",
+          "DNSName"
         ]
       }
     }
+  },
+  "Conditions": {
+    "CDKMetadataAvailable": {
+      "Fn::Or": [
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "af-south-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-east-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-northeast-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-northeast-2"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-south-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-southeast-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ap-southeast-2"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "ca-central-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "cn-north-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "cn-northwest-1"
+              ]
+            }
+          ]
+        },
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-central-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-north-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-south-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-west-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-west-2"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "eu-west-3"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "me-south-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "sa-east-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-east-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-east-2"
+              ]
+            }
+          ]
+        },
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-west-1"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "AWS::Region"
+                },
+                "us-west-2"
+              ]
+            }
+          ]
+        }
+      ]
+    }
   }
+}


### PR DESCRIPTION
Changing IAM policy of  AWS KMS key XWikiEncryptionKey and XWikiSecretEncryptionKey, by setting the principal key administrator of both to the root ARN 